### PR TITLE
Allow mainM to generate arbitrary LLVM ASM files

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,4 +4,4 @@ module Main where
 import Eel
 
 main :: IO ()
-main = mainM $ \(argc, _argv) -> add (lit 42) argc
+main = mainM "main.ll" $ \(argc, _argv) -> add (lit 42) argc

--- a/src/Eel.hs
+++ b/src/Eel.hs
@@ -638,10 +638,10 @@ getelementptr p i = assign ["getelementptr", tyvalof p `comma` tyvalof i]
 -- %v2 = sub i32 %v0, 1
 -- ret i32 %v2
 -- }
-mainM :: ((V Int32, V (Ptr (Ptr Char))) -> I Int32) -> IO ()
-mainM f = do
+mainM :: String -> ((V Int32, V (Ptr (Ptr Char))) -> I Int32) -> IO ()
+mainM filename f = do
   let st = execState (define "eel_main" f ty tyvalof) $ St initContext [] [] []
-  writeFile "t.ll" $ unlines $ concat $ reverse $ snd <$> namespace st
+  writeFile filename $ unlines $ concat $ reverse $ snd <$> namespace st
       
 -- | Quick and dirty representation of LLVM labels.
 -- http://llvm.org/docs/LangRef.html#label-type

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -81,7 +81,7 @@ allocn :: Ty a => Int' -> M (Ptr a)
 allocn = fun alloca
 
 mainM :: M () -> IO ()
-mainM m = E.mainM $ \(_argc, _argv) -> m >> lit 0
+mainM m = E.mainM "t.ll" $ \(_argc, _argv) -> m >> lit 0
   
 while :: Bool' -> M ()
 while x = do


### PR DESCRIPTION
Add an additional paramter to mainM::Eel.hs that specifies a filename
for the resulting LLVM assembly.

So I started to run into trouble when trying to build a couple of different examples in the repo at the same time. Not sure if this is how we'd want to go about this, but having support for an arbitrarily named .ll file seems useful.
